### PR TITLE
fix: revert setter and make label readonly

### DIFF
--- a/src/marker.test.ts
+++ b/src/marker.test.ts
@@ -45,6 +45,15 @@ beforeEach(() => {
   google.maps.event.addDomListener = jest.fn();
 });
 
+test("init should not pass extended options", () => {
+  const marker = new MarkerWithLabel({
+    labelContent: "foo",
+    labelClass: "bar",
+    clickable: true,
+  });
+  expect(google.maps.Marker).toBeCalledWith({ clickable: true });
+});
+
 test("should have listeners after multiple calls to setMap", () => {
   const map = (jest.fn() as any) as google.maps.Map;
   (google.maps.Marker.prototype.getMap as jest.Mock).mockImplementation(() => {

--- a/src/marker.ts
+++ b/src/marker.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { abortEvent, stopPropagation } from "./util";
+import { abortEvent, omit, stopPropagation } from "./util";
 
 import { Label } from "./label";
 import { MarkerSafe } from "./marker-safe";
@@ -49,7 +49,15 @@ export class MarkerWithLabel extends MarkerSafe {
   private mouseOutTimeout: ReturnType<typeof setTimeout>;
 
   constructor(options: MarkerWithLabelOptions) {
-    super({ ...options });
+    // need to omit extended options to Marker class that collide with setters/getters
+    super(
+      omit(options, [
+        "labelAnchor",
+        "labelZIndexOffset",
+        "labelClass",
+        "labelContent",
+      ])
+    );
     this.label = new Label({ ...{}, ...options });
 
     this.propertyListeners = [

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,3 +51,13 @@ export function stopPropagation(e: Event | null) {
     e.cancelBubble = true;
   }
 }
+
+export function omit(
+  o: { [key: string]: any },
+  keys: string[]
+): { [key: string]: any } {
+  const x = { ...o };
+
+  keys.forEach((k) => delete x[k]);
+  return x;
+}


### PR DESCRIPTION
This pull request omits the extended options of the `MarkerWithLabel` class from being passed to the `Marker` class.

fixes #128 
fixes: #132