### PR TITLE
fix: mouseout event triggers delay even when user is not dragging label

### DIFF
--- a/src/marker.ts
+++ b/src/marker.ts
@@ -159,26 +159,33 @@ export class MarkerWithLabel extends MarkerSafe {
             if (this.mouseOutTimeout) {
               clearTimeout(this.mouseOutTimeout);
             }
-            this.mouseOutTimeout = setTimeout(() => {
-              if (this.isMouseDownOnLabel) {
-                this.isMouseDownOnLabel = false;
-                google.maps.event.trigger(this, MOUSEUP, {
-                  latLng: this.getPosition(),
-                });
 
-                if (this.isDraggingLabel) {
-                  this.isDraggingLabel = false;
-                  this.shouldIgnoreClick = true;
-                  google.maps.event.trigger(this, DRAGEND, {
+            if (this.isMouseDownOnLabel) {
+              this.mouseOutTimeout = setTimeout(() => {
+                if (this.isMouseDownOnLabel) {
+                  this.isMouseDownOnLabel = false;
+                  google.maps.event.trigger(this, MOUSEUP, {
                     latLng: this.getPosition(),
                   });
-                }
-              }
 
+                  if (this.isDraggingLabel) {
+                    this.isDraggingLabel = false;
+                    this.shouldIgnoreClick = true;
+                    google.maps.event.trigger(this, DRAGEND, {
+                      latLng: this.getPosition(),
+                    });
+                  }
+                }
+
+                google.maps.event.trigger(this, MOUSEOUT, {
+                  latLng: this.getPosition(),
+                });
+              }, 200);
+            } else {
               google.maps.event.trigger(this, MOUSEOUT, {
                 latLng: this.getPosition(),
               });
-            }, 200);
+            }
 
             abortEvent(e);
           }


### PR DESCRIPTION
Fixes #134 

The mouseout delay is now only used when the user has their mouse down on label, the event is triggered without delay if it was a simple hover.