### PR TITLE
fix: remove unnecessary code setting classes on divs

### DIFF
--- a/src/label.ts
+++ b/src/label.ts
@@ -198,10 +198,6 @@ export class Label extends OverlayViewSafe {
     this.labelDiv = document.createElement("div");
     this.eventDiv = document.createElement("div");
 
-    // default class names
-    this.labelDiv.classList.add(LABEL_CLASS);
-    this.labelDiv.classList.add(EVENT_CLASS);
-
     // default styles for both divs
     this.labelDiv.style.position = ABSOLUTE;
     this.eventDiv.style.position = ABSOLUTE;


### PR DESCRIPTION
closes #514

This code setting the classlist is called at a later point in the constructor.