### PR TITLE
fix: Replace deprecated addDomListener call

### DIFF
--- a/src/label.ts
+++ b/src/label.ts
@@ -185,8 +185,9 @@ export class Label extends OverlayViewSafe {
   public addDomListener(
     event: string,
     handler: (event: Event) => void
-  ): google.maps.MapsEventListener {
-    return google.maps.event.addDomListener(this.eventDiv, event, handler);
+    ): google.maps.MapsEventListener {
+    this.eventDiv.addEventListener(event, handler);
+    return { remove: () => this.eventDiv.removeEventListener(event, handler) };
   }
 
   public onRemove(): void {

--- a/src/marker.test.ts
+++ b/src/marker.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 
   Label.prototype.setMap = jest.fn();
 
-  google.maps.event.addDomListener = jest.fn();
+  Label.prototype.addDomListener = jest.fn();
 });
 
 test("init should not pass extended options", () => {
@@ -82,7 +82,7 @@ test("should have interactive listeners", () => {
   marker["addInteractiveListeners"]();
 
   expect(
-    (google.maps.event.addDomListener as any).mock.calls.map((c: any[]) => c[1])
+    (Label.prototype.addDomListener as any).mock.calls.map((c: any[]) => c[0])
   ).toMatchInlineSnapshot(`
     Array [
       "mouseover",
@@ -105,7 +105,7 @@ test("should not have interactive listeners if no map", () => {
   });
   marker["addInteractiveListeners"]();
 
-  expect(google.maps.event.addDomListener as jest.Mock).toHaveBeenCalledTimes(
+  expect(Label.prototype.addDomListener as jest.Mock).toHaveBeenCalledTimes(
     0
   );
 });

--- a/src/marker.test.ts
+++ b/src/marker.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
 
   Label.prototype.setMap = jest.fn();
 
-  Label.prototype.addDomListener = jest.fn();
+  HTMLElement.prototype.addEventListener = jest.fn();
 });
 
 test("init should not pass extended options", () => {
@@ -82,7 +82,7 @@ test("should have interactive listeners", () => {
   marker["addInteractiveListeners"]();
 
   expect(
-    (Label.prototype.addDomListener as any).mock.calls.map((c: any[]) => c[0])
+    (HTMLElement.prototype.addEventListener as any).mock.calls.map((c: any[]) => c[0])
   ).toMatchInlineSnapshot(`
     Array [
       "mouseover",
@@ -105,7 +105,7 @@ test("should not have interactive listeners if no map", () => {
   });
   marker["addInteractiveListeners"]();
 
-  expect(Label.prototype.addDomListener as jest.Mock).toHaveBeenCalledTimes(
+  expect(HTMLElement.prototype.addEventListener as jest.Mock).toHaveBeenCalledTimes(
     0
   );
 });


### PR DESCRIPTION
Fixes #562 

Keeps the MapsEventListener even if it does not seem to be used currently instead of returning void